### PR TITLE
Using Azure Pipeline to install JupyterHub on the Kubernetes cluster

### DIFF
--- a/.az-pipelines/continuous-deployment.yml
+++ b/.az-pipelines/continuous-deployment.yml
@@ -10,6 +10,8 @@ pool:
 
 # List of environment variables to be used throughout the pipeline.
 # Mostly consists of software versions and namespaces.
+# Versions 'jupyterhub_chart_version' can be found at the following URL:
+#     https://jupyterhub.github.io/helm-chart/
 variables:
   helm_version: '2.15.0'
   jupyterhub_chart_version: '0.8.2'


### PR DESCRIPTION
### Summary

This PR extends the continuous deployment azure pipeline to install/upgrade the JupyterHub helm chart. Will fix #2 

### What's changed?

- Bash task added to CD pipeline to pull and update the JupyterHub helm chart repository
- Helm task added to the CD pipeline to install and upgrade the JupyterHub helm chart to the Kubernetes cluster
- Added an environment variable holding the version of the JupyterHub helm chart and documented where this version number can be found.