### PR TITLE
[DOCS] Add comments to Azure pipeline

### DIFF
--- a/.az-pipelines/continuous-deployment.yml
+++ b/.az-pipelines/continuous-deployment.yml
@@ -10,8 +10,13 @@ pool:
 
 # List of environment variables to be used throughout the pipeline.
 # Mostly consists of software versions and namespaces.
+#
 # Versions 'jupyterhub_chart_version' can be found at the following URL:
 #     https://jupyterhub.github.io/helm-chart/
+#
+# JupyterHub HELM CHART version 0.8.2 corresponds to JUPYTERHUB version 0.9.6
+# See which version of JUPYTERHUB the HELM CHART installs here:
+#     https://github.com/jupyterhub/zero-to-jupyterhub-k8s/tags
 variables:
   helm_version: '2.15.0'
   jupyterhub_chart_version: '0.8.2'


### PR DESCRIPTION
The version of the HELM CHART is not a direct translation to the
version of the JUPYTERHUB code base we are installing. Version
0.8.2 of the HELM CHART corresponds to version 0.9.6 of the
JUPYTERHUB code base. A comment reflecting this and linking to the
z2jh-k8s tag documentation has been added to the Azure Pipeline
above the environment variables where we set the Helm Chart version