### PR TITLE
Mounting Azure fileshare with shared data to JupyterHub

### DIFF
--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -39,4 +39,4 @@ singleuser:
           readOnly: false
     extraVolumeMounts:
       - name: bridge-shared-data
-        mountPath: /home/data
+        mountPath: /home/joyvan/data


### PR DESCRIPTION
### Summary

This PR attaches a shared data folder from an Azure Fileshare to user pods.

Docs:

- https://zero-to-jupyterhub.readthedocs.io/en/latest/customizing/user-storage.html#additional-storage-volumes
- https://docs.microsoft.com/en-us/azure/aks/azure-files-volume

### What's changed?

- An Azure Fileshare has been created in the `bridge-data-platform` resource group
- The key to this storage account has been added as a Kubernetes secret to the cluster
- The JupyterHub config has been updated to mount the fileshare (using the above secret) to user pods as a Volume Mount