### PR TITLE
Require that core pods stay on a labelled node for efficient autoscaling

### DIFF
--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -40,8 +40,12 @@ scheduling:
   userScheduler:
     enabled: true
 
-# Set resource limits to efficiently pack users onto nodes
 singleuser:
+  # Require core pods to stay on labelled node
+  corePods:
+    nodeAffinity:
+      matchNodePurpose: require
+  # Set CPU and memory limits to efficiently pack users onto nodes
   cpu:
     limit: 0.5
     guarantee: 0.5
@@ -63,6 +67,7 @@ singleuser:
   image:
     name: jupyter/minimal-notebook
     tag: e255f1aa00b2
+  # Create profile lists for users to choose from
   profileList:
     - display_name: "Minimal environment"
       description: "A simple Python environment"


### PR DESCRIPTION
### Summary

We can use Kubernetes node/pod affinities to require that certain types of pod are only scheduled on certain identified nodes. This means that autoscaling is more efficient as k8s doesn't have to move long-running pods (such as the hub) around.

Docs/config:
- https://zero-to-jupyterhub.readthedocs.io/en/latest/administrator/optimization.html#using-a-dedicated-node-pool-for-users
- https://zero-to-jupyterhub.readthedocs.io/en/latest/reference/reference.html#scheduling-corepods

### What's changed?

- `hub.jupyter.org/node-purpose=core` added to main node
- JupyterHub config updated to required that core pods are scheduled to the labelled node