### PR TITLE
Use whitelist and regex to block users

### DIFF
--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -10,7 +10,7 @@ auth:
     users: ["edaub", "sgibson91"]
   whitelist:
     users:
-      - "^(?!\w+).*$"
+      - "^(?!\\w+).*$"
 
 # Cull inactive pods to free up resources
 cull:


### PR DESCRIPTION
Control who can log in to the Hub in absence of a list of known users