### PR TITLE
Update docker image tags to most recent version on Docker Hub

### DIFF
--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -76,7 +76,7 @@ singleuser:
   # Define the default image
   image:
     name: jupyter/minimal-notebook
-    tag: e255f1aa00b2
+    tag: dc9744740e12
   # Create profile lists for users to choose from
   profileList:
     - display_name: "Minimal environment"
@@ -85,9 +85,9 @@ singleuser:
     - display_name: "Data Science Environment"
       description: "Includes Python, R, and Julia"
       kubespawner_override:
-        image: jupyter/datascience-notebook:e255f1aa00b2
+        image: jupyter/datascience-notebook:dc9744740e12
     - display_name: "Custom repo2docker image"
       # yamllint disable-line rule:line-length
       description: "Custom image built from the JupyterHub environment repo using repo2docker: https://github.com/alan-turing-institute/bridge-data-environment"
       kubespawner_override:
-        image: turinginst/bridge-data-env:2020.03.10-00ef4f7
+        image: turinginst/bridge-data-env:2020.03.10-c2c199f


### PR DESCRIPTION
This PR updates the image tags for the following Docker images: minimal-notebook, datascience-notebook, custom-repo2docker