### PR TITLE
Remove JupyterLab as default User Interface

### DIFF
--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -19,10 +19,6 @@ cull:
   every: 300
 
 hub:
-  # Use JupyterLab interface by default
-  extraConfig:
-    jupyterlab: |
-      c.Spawner.cmd = ['jupyter-labhub']
   networkPolicy:
     enabled: true
 
@@ -71,8 +67,6 @@ singleuser:
   memory:
     limit: 1G
     guarantee: 1G
-  # Use JupyterLab interface by default
-  defaultUrl: "/lab"
   # Define the default image
   image:
     name: jupyter/minimal-notebook


### PR DESCRIPTION
minimal-notebook env doesn't spawn correctly when JupyterLab is
set as the default user interface. Currently removing for now. Will
investigate whether it is possible to set specific URL endpoints for
the three envs in the Kubespawner docs.