### PR TITLE
Use cleanup-on-fail flag for helm upgrade

### DIFF
--- a/.az-pipelines/continuous-deployment.yml
+++ b/.az-pipelines/continuous-deployment.yml
@@ -117,4 +117,5 @@ jobs:
           chartName: 'jupyterhub/jupyterhub'
           releaseName: $(KUBERNETES_NAMESPACE)
           valueFile: '.secret/config.yaml'
-          arguments: '--version $(JUPYTERHUB_CHART_VERSION) --timeout 600 --cleanup-on-fail'
+          arguments: |
+            --version $(JUPYTERHUB_CHART_VERSION) --timeout 600 --cleanup-on-fail

--- a/.az-pipelines/continuous-deployment.yml
+++ b/.az-pipelines/continuous-deployment.yml
@@ -117,4 +117,4 @@ jobs:
           chartName: 'jupyterhub/jupyterhub'
           releaseName: $(KUBERNETES_NAMESPACE)
           valueFile: '.secret/config.yaml'
-          arguments: '--version $(JUPYTERHUB_CHART_VERSION) --timeout 600'
+          arguments: '--version $(JUPYTERHUB_CHART_VERSION) --timeout 600 --cleanup-on-fail'

--- a/.az-pipelines/continuous-deployment.yml
+++ b/.az-pipelines/continuous-deployment.yml
@@ -118,4 +118,5 @@ jobs:
           releaseName: $(KUBERNETES_NAMESPACE)
           valueFile: '.secret/config.yaml'
           arguments: |
-            --version $(JUPYTERHUB_CHART_VERSION) --timeout 600 --cleanup-on-fail
+            --version $(JUPYTERHUB_CHART_VERSION) \
+            --timeout 600 --cleanup-on-fail


### PR DESCRIPTION
This will prevent such error messages as "Cannot upgrade, resource X already exists"