### PR TITLE
Update image tags in config, update script to check image tags

### DIFF
--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -70,7 +70,7 @@ singleuser:
   # Define the default image
   image:
     name: jupyter/minimal-notebook
-    tag: dc9744740e12
+    tag: 584e9ab39d22
   # Create profile lists for users to choose from
   profileList:
     - display_name: "Minimal environment"
@@ -79,11 +79,11 @@ singleuser:
     - display_name: "Data Science Environment"
       description: "Includes Python, R, and Julia"
       kubespawner_override:
-        image: jupyter/datascience-notebook:dc9744740e12
+        image: jupyter/datascience-notebook:584e9ab39d22
     - display_name: "Custom repo2docker image"
       # yamllint disable-line rule:line-length
       description: "Custom image built from the JupyterHub environment repo using repo2docker: https://github.com/alan-turing-institute/bridge-data-environment"
       kubespawner_override:
-        image: turinginst/bridge-data-env:2020.03.10-c2c199f
+        image: turinginst/bridge-data-env:2020.04.14-eb5bb8f
   # Use JupyterLab interface by default
   defaultUrl: "/lab"

--- a/scripts/update_docker_tags.py
+++ b/scripts/update_docker_tags.py
@@ -3,7 +3,7 @@ import json
 import yaml
 import requests
 
-HERE = os.path.dirname(__file__)
+SCRIPTS_PATH = "scripts"
 ABSOLUTE_HERE = os.path.dirname(os.path.realpath(__file__))
 IMAGE_LIST = ["minimal-notebook", "datascience-notebook", "repo2docker"]
 
@@ -50,8 +50,8 @@ def get_config_filepath():
     """
     tmp = ABSOLUTE_HERE.split("/")
 
-    if HERE in tmp:
-        tmp.remove(HERE)
+    if SCRIPTS_PATH in tmp:
+        tmp.remove(SCRIPTS_PATH)
 
     tmp.extend(["config", "config-template.yaml"])
 


### PR DESCRIPTION
This PR does two things:

1. Updates the image tags referenced in `config-template.yml` to be the most recent tags on Docker Hub
2. Changes the `HERE` param in `update_docker_tags.py` to `SCRIPTS_PATH` so that the script can be run from either `./` or `./scripts` without throwing an error