### PR TITLE
Expose proxy as LoadBalancer type

### DIFF
--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -31,6 +31,9 @@ proxy:
   secretToken: "<proxySecretToken>"
   networkPolicy:
     enabled: true
+  # Expose proxy as loadbalancer (default for 0.8.2 is ClusterIP)
+  service:
+    type: LoadBalancer
   # Secure connection via https (certificates automatically renew)
   https:
     hosts:


### PR DESCRIPTION
The default type exposed is ClusterIP for the JupyterHub version we're running, see [ref](https://zero-to-jupyterhub.readthedocs.io/en/0.8.2/reference.html#proxy). In latest version the default is LoadBalancer, see [ref](https://zero-to-jupyterhub.readthedocs.io/en/latest/reference/reference.html#proxy-service-type).