### PR TITLE
Add explicit install if resource doesn't already exist.

### DIFF
--- a/.az-pipelines/continuous-deployment.yml
+++ b/.az-pipelines/continuous-deployment.yml
@@ -120,5 +120,6 @@ jobs:
           chartName: "jupyterhub/jupyterhub"
           releaseName: $(KUBERNETES_NAMESPACE)
           valueFile: ".secret/config.yaml"
+          install: true
           # yamllint disable-line rule:line-length
           arguments: "--version $(JUPYTERHUB_CHART_VERSION) --timeout 600 --cleanup-on-fail"


### PR DESCRIPTION
Value is true by default but I wanted to add it explicitly to be clear (I've also just purged the bridgehub namespace and want to trigger installing it fresh).