### PR TITLE
Add Hub admin users in Azure AD authentication, and exclude all other users for now.

### DIFF
--- a/.az-pipelines/continuous-deployment.yml
+++ b/.az-pipelines/continuous-deployment.yml
@@ -32,7 +32,7 @@ steps:
       KeyVaultName: $(KEY_VAULT_NAME)
       SecretsFilter: "proxySecretToken, githubClientId, githubClientSecret, \
         letsEncryptContactEmail, azureADClientId, azureADClientSecret, \
-        azureADTenantId"
+        azureADTenantId, hubAdminUsersList"
 
   - bash: |
       mkdir -p .secret
@@ -43,6 +43,7 @@ steps:
       -e "s/<azureADClientId>/$(azureADClientId)/" \
       -e "s/<azureADClientSecret>/$(azureADClientSecret)/" \
       -e "s/<azureADTenantId>/$(azureADTenantId)/" \
+      -e "s/<hubAdminUsersList>/$(hubAdminUsersList)/" \
       config/config-template.yaml > .secret/config.yaml
     displayName: "Generate .secret/config.yaml"
 

--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -19,7 +19,7 @@ auth:
     callbackUrl: "https://hub.bridge-data-platform.turing.ac.uk/hub/oauth_callback"
   admin:
     access: true
-    users: ["<hubAdminUsersList>"]
+    users: <hubAdminUsersList>
   whitelist:
     # exclude all for now until we have other allowed users
     users:

--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -7,12 +7,6 @@
 #     # yamllint disable-line rule:line-length
 #     callbackUrl:
 #       "http://hub.bridge-data-platform.turing.ac.uk/hub/oauth_callback"
-#   admin:
-#     access: true
-#     users: ["edaub", "sgibson91", "annahadji"]
-#   whitelist:
-#     users:
-#       - "^(?!\\w+).*$"
 
 # Authenticate users with Azure AD
 auth:
@@ -23,6 +17,13 @@ auth:
     tenantId: "<azureADTenantId>"
     # yamllint disable-line rule:line-length
     callbackUrl: "https://hub.bridge-data-platform.turing.ac.uk/hub/oauth_callback"
+  admin:
+    access: true
+    users: ["<hubAdminUsersList>"]
+  whitelist:
+    # exclude all for now until we have other allowed users
+    users:
+      - "^(?!\\w+).*$"
 
 hub:
   networkPolicy:


### PR DESCRIPTION
This doesn't look to be released in JupyterHub chart version 0.9.1 yet, but `whitelist` will need to be changed when using future versions of JupyterHub (see JupyterHub issue [299](https://github.com/jupyterhub/team-compass/issues/299)).

Admin users have been moved to Azure Key Vault.